### PR TITLE
Add unit tests to check handling of invalid arguments

### DIFF
--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -121,6 +121,8 @@ def test_attacks_init_raises_exception(
 
 targeted_attacks_raises_exception: List[Tuple[Type[fbn.Attack], bool]] = [
     (fbn.attacks.EADAttack(), True),
+    (fbn.attacks.DDNAttack(), True),
+    (fbn.attacks.L2CarliniWagnerAttack(), True),
 ]
 
 
@@ -147,6 +149,10 @@ def test_targeted_attacks_call_raises_exception(
     invalid_targeted_criterion = fbn.TargetedMisclassification(invalid_target_classes)
 
     class DummyCriterion(fbn.Criterion):
+        """Criterion without any functionality which is just meant to be
+        rejected by the attacks
+        """
+
         def __repr__(self) -> str:
             return ""
 

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -84,38 +84,14 @@ def test_targeted_attacks(
     assert adv_after_attack.sum().item() > adv_before_attack.sum().item()
 
 
-attacks_init_raises_exception: List[Tuple[Type[fbn.Attack], dict, Type, str, bool]] = [
-    (
-        fbn.attacks.EADAttack,
-        dict(binary_search_steps=3, steps=20, decision_rule="L2"),
-        ValueError,
-        "invalid decision rule",
-        True,
-    ),
-]
-
-
-@pytest.mark.parametrize(
-    "attack_exception_text_and_grad", attacks_init_raises_exception
-)
-def test_attacks_init_raises_exception(
-    fmodel_and_data: Tuple[fbn.Model, ep.Tensor, ep.Tensor],
-    attack_exception_text_and_grad: Tuple[fbn.Attack, Type, str, bool],
-) -> None:
-
-    (
-        attack_type,
-        attack_arguments,
-        target_exception_type,
-        target_exception_text,
-        attack_uses_grad,
-    ) = attack_exception_text_and_grad
-
-    with pytest.raises(target_exception_type) as excinfo:
-        attack_type(**attack_arguments)
+def test_ead_init_raises():
+    with pytest.raises(ValueError) as excinfo:
+        fbn.attacks.EADAttack(binary_search_steps=3, steps=20, decision_rule="L2")
 
     exception_text = str(excinfo.value)
-    exception_text_found = re.search(target_exception_text, exception_text) is not None
+    exception_text_found = (
+        re.search("invalid decision rule", exception_text) is not None
+    )
     assert exception_text_found
 
 

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -157,8 +157,10 @@ def test_targeted_attacks_call_raises_exception(
 
     invalid_criterion = DummyCriterion()
 
+    # check if targeted attack criterion with invalid number of classes is rejected
     with pytest.raises(ValueError):
         attack(fmodel, x, invalid_targeted_criterion)
 
+    # check if only the two valid criteria are accepted
     with pytest.raises(ValueError):
         attack(fmodel, x, invalid_criterion)


### PR DESCRIPTION
This PR adds two types of unit tests: one for checking if incorrect arguments during the attack's initialization are correctly rejected and one for doing the same in the attack's `__call__` function.